### PR TITLE
Correção no comando "removeVip".

### DIFF
--- a/PixelVip-Spigot/pom.xml
+++ b/PixelVip-Spigot/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.2</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
 

--- a/PixelVip-Spigot/src/main/java/br/net/fabiozumbi12/pixelvip/bukkit/cmds/PVCommands.java
+++ b/PixelVip-Spigot/src/main/java/br/net/fabiozumbi12/pixelvip/bukkit/cmds/PVCommands.java
@@ -877,8 +877,12 @@ public class PVCommands implements CommandExecutor, TabCompleter, Listener {
 
             String uuid = plugin.getPVConfig().getVipUUID(args[0]);
             if (uuid != null) {
-                plugin.getPVConfig().removeVip(uuid, group);
-                sender.sendMessage(plugin.getUtil().toColor(plugin.getPVConfig().getLang("_pluginTag", "vipsRemoved")));
+                if (plugin.getPVConfig().containsVip(uuid, group.get())) {
+                    plugin.getPVConfig().removeVip(uuid, group);
+                    sender.sendMessage(plugin.getUtil().toColor(plugin.getPVConfig().getLang("_pluginTag", "vipsRemoved")));
+                } else {
+                    sender.sendMessage(plugin.getUtil().toColor(plugin.getPVConfig().getLang("_pluginTag", "playerNotThisVip")));
+                }
             } else {
                 sender.sendMessage(plugin.getUtil().toColor(plugin.getPVConfig().getLang("_pluginTag", "playerNotVip")));
             }

--- a/PixelVip-Spigot/src/main/java/br/net/fabiozumbi12/pixelvip/bukkit/config/PVConfig.java
+++ b/PixelVip-Spigot/src/main/java/br/net/fabiozumbi12/pixelvip/bukkit/config/PVConfig.java
@@ -152,6 +152,7 @@ public class PVConfig {
         comConfig.setDefault("strings.listItemKeys", "&aList of Item Keys:");
         comConfig.setDefault("strings.vipInfoFor", "&aVip info for ");
         comConfig.setDefault("strings.playerNotVip", "&cThis player(or you) is not VIP!");
+        comConfig.setDefault("strings.playerNotThisVip", "&cThis player(or you) does not have this VIP.");
         comConfig.setDefault("strings.moreThanZero", "&cThis number need to be more than 0");
         comConfig.setDefault("strings.keyGenerated", "&aGenerated a key with the following:");
         comConfig.setDefault("strings.uniqueKeyGenerated", "&aGenerated a unique key with the following:");
@@ -906,6 +907,10 @@ public class PVConfig {
 
     public boolean groupExists(String group) {
         return comConfig.configurations.contains("groups." + group);
+    }
+
+    public boolean containsVip(String uuid, String vip) {
+        return dataManager.containsVip(uuid, vip);
     }
 
     public Set<String> getCmdChances(String vip) {


### PR DESCRIPTION
Correção no comando "removeVip" aonde todos os VIPs do jogador são removidos ao utilizar o comando tentando remover apenas um único VIP especifico que o jogador não contém no momento.